### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make-layer NAME RUNTIME MANIFEST
 ```
 
 *  `NAME` is a valid Lambda layer name (letters, numbers, hyphens, and underscores)
-*  `RUNTIME` is a valid Lambda runtime identifier (e.g. `nodejs10.x`, `python3.8`)
+*  `RUNTIME` is a valid Lambda runtime identifier (e.g. `nodejs14.x`, `python3.8`)
 *  `MANIFEST` is the full path and filename of a valid manifest file. The following
    types are supported:
    *  Node.js: [`package.json`](https://docs.npmjs.com/files/package.json/)


### PR DESCRIPTION
CloudFormation templates in aws-lambda-layer-builder have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.